### PR TITLE
Add PR preview deployments to GitHub Pages

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,29 +1,29 @@
-name: Deploy to GitHub Pages
+name: PR Preview
 
 on:
-  push:
-    branches: [main]
-  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
 
 permissions:
   contents: write
+  pull-requests: write
 
-concurrency:
-  group: pages
-  cancel-in-progress: false
+concurrency: preview-${{ github.ref }}
 
 jobs:
-  build-and-deploy:
+  preview:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - name: Install pnpm
+        if: github.event.action != 'closed'
         uses: pnpm/action-setup@v4
         with:
           version: 10
 
       - name: Use Node.js
+        if: github.event.action != 'closed'
         uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -31,17 +31,18 @@ jobs:
           cache-dependency-path: v2/frontend/pnpm-lock.yaml
 
       - name: Install dependencies
+        if: github.event.action != 'closed'
         working-directory: v2/frontend
         run: pnpm install --frozen-lockfile
 
       - name: Build
+        if: github.event.action != 'closed'
         working-directory: v2/frontend
         env:
-          BASE_URL: /bank-transactions-summarizer/
+          BASE_URL: /bank-transactions-summarizer/pr-preview/pr-${{ github.event.number }}/
         run: pnpm run build
 
-      - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Deploy PR Preview
+        uses: rossjrw/pr-preview-action@v1
         with:
-          folder: v2/frontend/dist
-          clean-exclude: pr-preview
+          source-dir: v2/frontend/dist/

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 concurrency: preview-${{ github.ref }}
 
 jobs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,3 +28,4 @@ Do NOT run `npx playwright` or `pnpm run test:e2e` directly.
 ## Developing rules
 
 - ✅ ALWAYS include screenshots in PR descriptions. Put them in folder "screenshots" at repository root.
+- ✅ ALWAYS include the PR preview link in PR descriptions: `https://yngvark.github.io/bank-transactions-summarizer/pr-preview/pr-<number>/`


### PR DESCRIPTION
Switch from artifact-based to branch-based GitHub Pages deployment so
that PR previews can coexist alongside the main site. Each PR gets
deployed to /pr-preview/pr-<number>/ and cleaned up on close.

- deploy.yml: use JamesIves/github-pages-deploy-action with
  clean-exclude to preserve pr-preview/ directory
- pr-preview.yml: build PR branch with correct BASE_URL and deploy
  via rossjrw/pr-preview-action, which also posts a comment with
  the preview URL

https://claude.ai/code/session_01GGKgyYzBNo5wZeHTVCgBvB