### PR TITLE
fix: isolate dev server so killing it doesn't kill Claude Code (#68)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,16 @@ Verify changes locally with `make ci` (runs unit + E2E tests). Do NOT run `npx p
 
 GitHub CI is slow. Use `make ci` as the main verification method. Only check GitHub CI once all local work is complete — this keeps the feedback loop fast.
 
+## Running the dev server (agents only)
+
+Prefer `make ci` for verification — it does not need a long-lived dev server. If you must run the dev server (e.g. interactive UI poking), use the tracked targets:
+
+- Start: `make run-bg` — starts Vite detached in its own session (`setsid`), writes PID to `/tmp/bts-dev.pid`, log to `/tmp/bts-dev.log`.
+- Stop: `make stop` — kills the tracked PID's process group; falls back to `fuser` on the port if no PID file is present.
+- Tail: `tail -f /tmp/bts-dev.log`.
+
+NEVER use `lsof -ti:PORT | xargs kill` from a Bash tool invocation. On environments where `lsof` is busybox (no `-ti` support), the command outputs garbage PIDs and `xargs kill` then signals random processes, including Claude Code itself (issue #68). Always kill by PID, or use `fuser PORT/tcp PORT/tcp6 -k`.
+
 ## Pull requests
 
 - ✅ ALWAYS include screenshots in PR descriptions. Put them in `screenshots/` at repository root.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-.PHONY: dev help install build run stop serve ci install-e2e
+.PHONY: dev help install build run run-bg stop serve ci install-e2e
 
 PORT ?= 5173
+PID_FILE ?= /tmp/bts-dev.pid
+LOG_FILE ?= /tmp/bts-dev.log
 
 help: ## Show this help message
 	@grep -E '^[a-zA-Z_0-9-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -13,12 +15,38 @@ build: install ## Build frontend
 	@echo "Building frontend..."
 	@(cd v2/frontend && pnpm run build)
 
-run: install ## Run frontend in development mode (use PORT=XXXX for custom port)
+run: install ## Run frontend in development mode, foreground (use PORT=XXXX for custom port)
 	@echo "Starting development server on port $(PORT)..."
 	@(cd v2/frontend && PORT=$(PORT) pnpm run dev)
 
-stop: ## Stop the development server
-	@lsof -ti:$(PORT) | xargs kill 2>/dev/null && echo "Stopped server on port $(PORT)" || echo "No server running on port $(PORT)"
+run-bg: install ## Start dev server detached in its own session (PID at $(PID_FILE), log at $(LOG_FILE))
+	@if [ -f $(PID_FILE) ] && kill -0 $$(cat $(PID_FILE)) 2>/dev/null; then \
+		echo "Dev server already running (PID $$(cat $(PID_FILE))). Run 'make stop' first."; exit 1; \
+	fi
+	@rm -f $(PID_FILE)
+	@echo "Starting detached dev server on port $(PORT) (log: $(LOG_FILE))..."
+	@cd v2/frontend && PORT=$(PORT) setsid pnpm run dev </dev/null >$(LOG_FILE) 2>&1 & echo $$! > $(PID_FILE)
+	@echo "Started (PID $$(cat $(PID_FILE))). Tail with: tail -f $(LOG_FILE). Stop with: make stop."
+
+stop: ## Stop the development server (prefers PID file, falls back to fuser)
+	@if [ -f $(PID_FILE) ]; then \
+		PID=$$(cat $(PID_FILE)); \
+		if kill -0 $$PID 2>/dev/null; then \
+			kill -- -$$PID 2>/dev/null || kill $$PID 2>/dev/null; \
+			echo "Stopped server (PID $$PID)"; \
+		else \
+			echo "Stale PID file (process $$PID not running)"; \
+		fi; \
+		rm -f $(PID_FILE); \
+	elif command -v fuser >/dev/null 2>&1; then \
+		if fuser -k -TERM $(PORT)/tcp $(PORT)/tcp6 >/dev/null 2>&1; then \
+			echo "Stopped server on port $(PORT) (no PID file, via fuser)"; \
+		else \
+			echo "No server running on port $(PORT)"; \
+		fi; \
+	else \
+		echo "No PID file at $(PID_FILE), and fuser is unavailable. Start the dev server with 'make run-bg' so its PID is tracked, or stop it manually."; \
+	fi
 
 install-e2e: ## Install E2E test dependencies
 	@(cd v2 && pnpm install)

--- a/docs/DESIGN-issue-68-dev-server-isolation.md
+++ b/docs/DESIGN-issue-68-dev-server-isolation.md
@@ -1,0 +1,52 @@
+# Issue #68: Dev-server isolation from Claude Code
+
+## Problem
+
+Claude Code occasionally exits with `Exit code 144` when stopping the Vite dev server. The trigger pattern is:
+
+```bash
+lsof -ti:5173 | xargs -r kill 2>/dev/null
+```
+
+Exit 144 = 128 + 16. Signal 16 is `SIGSTKFLT` on Linux / `SIGURG` on macOS — the agent's process tree was signaled by a kill it issued itself.
+
+## Root cause
+
+Two issues compound:
+
+1. **Port-based kill is fragile.** `lsof -ti:PORT | xargs kill` assumes `lsof -t` outputs only matching PIDs. On environments where `lsof` is **busybox** (a single 800KB multi-call binary), `-ti:PORT` flags are silently ignored and lsof dumps every process's open files. `xargs kill` then receives a stream of unrelated tokens (PIDs, file descriptors, paths) and signals random processes — including Claude Code's own bash process.
+2. **Same process group.** Even with real `lsof`, the dev server started as `(cd ... && pnpm dev) &` inherits the agent shell's process group. Process-group-targeted signals propagate up.
+
+Item 1 is the dominant cause in the Claude Code execution sandbox; item 2 matters on real Linux/macOS.
+
+## Fix
+
+Two complementary changes:
+
+### Makefile
+
+- New `make run-bg` target starts the dev server with `setsid`, putting it in its own session/process group. PID is recorded at `/tmp/bts-dev.pid`, stdout/stderr at `/tmp/bts-dev.log`. Returns immediately.
+- `make stop` now prefers the PID file: `kill -- -PID` to signal the whole detached process group, then `rm` the PID file. If the PID file is absent it falls back to `fuser -k -TERM PORT/tcp PORT/tcp6` (covers Vite's IPv6 loopback default). The dangerous `lsof -ti:PORT | xargs kill` fallback is removed.
+- `make run` (foreground, interactive) is unchanged — humans Ctrl-C as before.
+
+### CLAUDE.md
+
+A short "Running the dev server (agents only)" section pointing agents at `make run-bg` / `make stop` and explicitly warning against `lsof -ti:PORT | xargs kill`.
+
+## Why not just track PIDs without setsid?
+
+PID tracking alone fixes the wrong-PID problem but not the process-group propagation problem. `setsid` is the seatbelt: even if a future contributor reintroduces a port-based kill, the dev server can't reach Claude Code's process group.
+
+## Why fuser, not lsof, in the fallback?
+
+`fuser PORT/tcp` is supported uniformly across busybox and util-linux fuser, and is harder to misuse: it kills only processes bound to the named port, never random PIDs from a malformed pipe. macOS lacks `fuser` by default — but macOS users land in the fallback only if they bypassed `make run-bg`, which is rare. The else branch prints a clear "use `make run-bg`" message rather than guessing.
+
+## Verification
+
+Tested in the agent sandbox (busybox lsof environment, where the bug originally reproduced):
+
+1. `make run-bg PORT=15173 ...` — server starts, PID file present, port serves HTTP 200.
+2. `/proc/$PID/status` shows `PPid: 1` (init), confirming detachment from the agent shell.
+3. `make stop` kills via PID file, port stops listening, Claude Code is unaffected.
+4. Started untracked dev server (no PID file), `make stop` falls back to `fuser` on `tcp6`, port stops listening.
+5. Re-running `make run-bg` while a tracked PID is alive errors out with a clear message.


### PR DESCRIPTION
## Summary

Closes #68. Two changes that together prevent Claude Code from getting killed when the dev server is stopped:

- **Makefile:** new `make run-bg` runs Vite under `setsid` (own session/process group), writes PID to `/tmp/bts-dev.pid`, log to `/tmp/bts-dev.log`. `make stop` prefers the PID file and signals the detached process group with `kill -- -PID`; the dangerous `lsof -ti:PORT | xargs kill` fallback is replaced with `fuser PORT/tcp PORT/tcp6 -k`. `make run` (foreground) is unchanged for human use.
- **CLAUDE.md:** new "Running the dev server (agents only)" section pointing agents at `make run-bg` / `make stop`, with an explicit warning against port-based kill via lsof.

Root cause: in agent execution sandboxes that ship busybox `lsof`, the `-ti:PORT` flags are silently ignored — lsof dumps every process's open files and `xargs kill` then signals random PIDs. Combined with shared process groups, that signal sometimes lands on Claude Code.

Design notes: `docs/DESIGN-issue-68-dev-server-isolation.md`.

## Test plan

- [x] `make run-bg PORT=15173 ...` — server starts, PID file written, port serves HTTP 200
- [x] `/proc/$PID/status` shows `PPid: 1` — confirms session detachment
- [x] `make stop` (PID-file path) — process killed, port closes, Claude Code survives
- [x] `make stop` (fuser fallback, no PID file) — kills via `fuser .../tcp6`, port closes
- [x] Re-running `make run-bg` while alive errors with a clear message
- [x] `make help` shows the new `run-bg` target